### PR TITLE
Add patch to use btGjkConvexCast for raycasting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ $(UNZIP_DIR)/CMakeLists.txt: bullet_gjk_accuracy_patch.diff
 	patch -p0 -i bullet_gjk_accuracy_patch.diff
 	mv $(UNZIP_DIR)/src/LinearMath/btScalar.h $(UNZIP_DIR)/src/LinearMath/btScalar.h.in
 	patch -p0 -i bullet_double_precision_patch.diff
+	patch -p0 -i bullet_use_btGjkConvexCast_patch.diff
 
 clean:
 	-if [ -e pod-build/install_manifest.txt ]; then rm -f `cat pod-build/install_manifest.txt`; fi

--- a/bullet_use_btGjkConvexCast_patch.diff
+++ b/bullet_use_btGjkConvexCast_patch.diff
@@ -1,0 +1,18 @@
+--- bullet-2.81-rev2613/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp	2015-01-13 16:58:05.015703412 -0500
++++ bullet-2.81-rev2613/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp	2015-01-13 16:50:55.705574578 -0500
+@@ -290,12 +290,12 @@
+ 
+ 		btConvexShape* convexShape = (btConvexShape*) collisionShape;
+ 		btVoronoiSimplexSolver	simplexSolver;
+-#define USE_SUBSIMPLEX_CONVEX_CAST 1
++//#define USE_SUBSIMPLEX_CONVEX_CAST 1
+ #ifdef USE_SUBSIMPLEX_CONVEX_CAST
+ 		btSubsimplexConvexCast convexCaster(castShape,convexShape,&simplexSolver);
+ #else
+-		//btGjkConvexCast	convexCaster(castShape,convexShape,&simplexSolver);
+-		//btContinuousConvexCollision convexCaster(castShape,convexShape,&simplexSolver,0);
++    btGjkConvexCast	convexCaster(castShape,convexShape,&simplexSolver);
++    //btContinuousConvexCollision convexCaster(castShape,convexShape,&simplexSolver,0);
+ #endif //#USE_SUBSIMPLEX_CONVEX_CAST
+ 
+ 		if (convexCaster.calcTimeOfImpact(rayFromTrans,rayToTrans,colObjWorldTransform,colObjWorldTransform,castResult))


### PR DESCRIPTION
This is better behaved than the default `btSubsimplexConvexCast`, which produces ripples in height maps. 