### PR TITLE
turn on dll for windows -- issue #1746

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BULLET_OPTIONS -DINSTALL_LIBS=on
 		 -DUSE_DOUBLE_PRECISION=on) 
 
 if (WIN32)
-	list(APPEND BULLET_OPTIONS -DUSE_MSVC_RUNTIME_LIBRARY_DLL=off)
+	list(APPEND BULLET_OPTIONS -DUSE_MSVC_RUNTIME_LIBRARY_DLL=on)
 else()
 	list(APPEND BULLET_OPTIONS -DBUILD_SHARED_LIBS=on)   # shared libs doesn't work with msvc (there aren't any dllexports defined) 
 endif()


### PR DESCRIPTION
This turns on dynamic linking when building with MSVC, which will allow drake to bullet with bullet on Windows.

Once this is merged then I need to update the git hash in the drake CMakeLists.txt file so that it pulls the update. Then the pull request existing in 1746 should also be accepted and the build should work.

See:
https://github.com/RobotLocomotion/drake/pull/1746