### PR TITLE
Use dummy install logic instead of custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ ExternalProject_Add_Step(bullet3 forceconfigure
 	DEPENDERS configure
 	ALWAYS 1)
 
-add_custom_target(install DEPENDS bullet3)  # just to have an explicit install rule
+install(CODE "message(\"Nothing to do for install.\")")
 
 if (APPLE)
 	set(BULLET_INSTALL_LIBS 


### PR DESCRIPTION
Similar to RobotLocomotion/lcm-pod#17 Rather than creating a custom target to override the install target, generate an install step that prints "Nothing to do for install.". 

